### PR TITLE
Exomiser 14.1.0 2502

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,0 @@
-[bumpversion]
-current_version = 0.1.0
-commit = True
-tag = False
-
-[bumpversion:file:pyproject.toml]
-[bumpversion:file:.github/workflows/docker.yaml]

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,17 +1,15 @@
 name: Docker
-
-## choose when this workflow runs
 on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
     inputs:
       tag:
         description: 'Tag to use (defaults to "test")'
         default: "test"
-
-## to build with each push to main (following a PR)
-#  push:
-#    branches:
-#      - main
 
 permissions:
   id-token: write

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -16,7 +16,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 0.1.0
+  VERSION: 0.1.1
 
 jobs:
   docker:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ default_language_version:
   python: python3.10
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: check-yaml
         exclude: '\.*conda/.*'
@@ -23,7 +23,7 @@ repos:
 
   # Static type analysis (as much as it's possible in python using type hints)
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.9.0"
+    rev: "v1.10.0"
     hooks:
       - id: mypy
         args: [--pretty, --show-error-codes, --install-types, --non-interactive]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV PYTHONDONTWRITEBYTECODE=1
 WORKDIR /cpg_exomiser
 
 COPY src src/
-COPY pyproject.toml README.md ./
+COPY pyproject.toml LICENSE README.md ./
 
 # pip install but don't retain the cache files
 RUN pip install --no-cache-dir .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,9 +31,10 @@ Repository = "https://github.com/populationgenomics/cpg-flow-exomiser"
 [project.optional-dependencies]
 # various requirements when running cpg-flow/analysis-runner
 test = [
-    'bump2version',
+    'bump-my-version',
     'pre-commit',
     'pytest',
+    'ruff',
 ]
 
 [project.scripts]
@@ -92,3 +93,21 @@ section-order = ["future", "standard-library", "third-party", "first-party", "lo
 # suppress the ARG002 "Unused method argument" warning in the stages.py file
 ## - we don't need any generic cpg-flow arguments, but need to fit the required method signature
 "src/cpg_exomiser/stages.py" = ["ARG002"]
+
+[tool.bumpversion]
+current_version = "0.1.0"
+parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
+serialize = ["{major}.{minor}.{patch}"]
+commit = true
+message = "Bump version: {current_version} → {new_version}"
+commit_args = ""
+
+[[tool.bumpversion.files]]
+filename = "pyproject.toml"
+search = "version='{current_version}'"
+replace = "version='{new_version}'"
+
+[[tool.bumpversion.files]]
+filename = ".github/workflows/docker.yaml"
+search = "VERSION: {current_version}"
+replace = "VERSION: {new_version}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='CPG-Flow implementation of Exomiser Workflow'
 readme = "README.md"
 # currently cpg-flow is restricted to 3.10
 requires-python = ">=3.10,<3.11"
-version='0.1.0'
+version="0.1.1"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -95,7 +95,7 @@ section-order = ["future", "standard-library", "third-party", "first-party", "lo
 "src/cpg_exomiser/stages.py" = ["ARG002"]
 
 [tool.bumpversion]
-current_version = "0.1.0"
+current_version = "0.1.1"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/cpg_exomiser/config_template.toml
+++ b/src/cpg_exomiser/config_template.toml
@@ -2,6 +2,9 @@
 name = 'exomiser'
 status_reporter = 'metamist'
 
+exomiser_version = '14.1.0'
+exomiser_data_version = '2502'
+
 # in addition to these fields, you will need to supply input_cohorts, and a sequencing_type
 # cpg-flow will use this to query metamist, and set up the pipeline framework
 
@@ -24,5 +27,9 @@ exomiser_parallel_chunks = 4
 check_expected_outputs = true
 
 [images]
-bcftools = "australia-southeast1-docker.pkg.dev/cpg-common/images/bcftools_120:1.20-1"
-exomiser = "australia-southeast1-docker.pkg.dev/cpg-common/images/exomiser_14:14.0.0-1"
+bcftools = "australia-southeast1-docker.pkg.dev/cpg-common/images/bcftools:1.21-2"
+exomiser = "australia-southeast1-docker.pkg.dev/cpg-common/images/exomiser:14.1.0-1"
+
+[references]
+exomiser_2502_pheno = "gs://cpg-common-main/references/exomiser_2502/phenotype"
+exomiser_2502_core = "gs://cpg-common-main/references/exomiser_2502/core"

--- a/src/cpg_exomiser/config_template.toml
+++ b/src/cpg_exomiser/config_template.toml
@@ -31,5 +31,7 @@ bcftools = "australia-southeast1-docker.pkg.dev/cpg-common/images/bcftools:1.21-
 exomiser = "australia-southeast1-docker.pkg.dev/cpg-common/images/exomiser:14.1.0-1"
 
 [references]
+exomiser_2402_pheno = "gs://cpg-common-main/references/exomiser_2402/phenotype"
+exomiser_2402_core = "gs://cpg-common-main/references/exomiser_2402/core"
 exomiser_2502_pheno = "gs://cpg-common-main/references/exomiser_2502/phenotype"
 exomiser_2502_core = "gs://cpg-common-main/references/exomiser_2502/core"

--- a/src/cpg_exomiser/jobs/RunExomiser.py
+++ b/src/cpg_exomiser/jobs/RunExomiser.py
@@ -2,7 +2,8 @@ from typing import TYPE_CHECKING
 
 from cpg_flow import utils
 from cpg_utils import config, hail_batch
-from cpg_exomiser.utils import EXOMISER_VERSION, EXOMISER_DATA_VERSION
+
+from cpg_exomiser.utils import EXOMISER_DATA_VERSION, EXOMISER_VERSION
 
 if TYPE_CHECKING:
     from hailtop.batch.job import BashJob

--- a/src/cpg_exomiser/stages.py
+++ b/src/cpg_exomiser/stages.py
@@ -12,21 +12,18 @@ from cpg_flow import stage, targets
 from cpg_utils import Path, config, hail_batch
 from loguru import logger
 
-from functools import cache
-
 from cpg_exomiser.jobs.CombineExomiserGeneTsvs import make_combine_exomiser_gene_tsvs_job
 from cpg_exomiser.jobs.CombineExomiserVariantTsvs import make_combine_exomiser_variant_tsvs_job
 from cpg_exomiser.jobs.MakeSingleFamilyPedFiles import extract_mini_ped_files
 from cpg_exomiser.jobs.MakeSingleFamilyPhenopackets import make_phenopackets
-
 from cpg_exomiser.jobs.MakeSingleFamilyVcfs import create_gvcf_to_vcf_jobs
 from cpg_exomiser.jobs.RunExomiser import run_exomiser
 from cpg_exomiser.utils import (
+    EXOMISER_DATA_VERSION,
+    EXOMISER_VERSION,
     find_previous_analyses,
     find_probands,
     find_seqr_projects,
-    EXOMISER_VERSION,
-    EXOMISER_DATA_VERSION,
 )
 
 
@@ -51,7 +48,7 @@ class MakeSingleFamilyVcfs(stage.DatasetStage):
         this now writes to a temporary bucket, we don't need these VCFs again in the future
         they cost more to keep than to regenerate
         """
-        prefix = dataset.tmp_prefix() / 'exomiser_inputs'
+        prefix = dataset.tmp_prefix() / 'exomiser' / 'inputs'
         return {proband: prefix / f'{proband}.vcf.bgz' for proband in find_probands(dataset)}
 
     def queue_jobs(self, dataset: targets.Dataset, inputs: stage.StageInput) -> stage.StageOutput:
@@ -71,7 +68,7 @@ class MakeSingleFamilyPhenopackets(stage.DatasetStage):
     """
 
     def expected_outputs(self, dataset: targets.Dataset) -> dict[str, Path]:
-        dataset_prefix = dataset.tmp_prefix() / 'exomiser_inputs'
+        dataset_prefix = dataset.tmp_prefix() / 'exomiser' / 'inputs'
         return {proband: dataset_prefix / f'{proband}_phenopacket.json' for proband in find_probands(dataset)}
 
     def queue_jobs(self, dataset: targets.Dataset, inputs: stage.StageInput) -> stage.StageOutput:
@@ -94,7 +91,7 @@ class MakeSingleFamilyPedFiles(stage.DatasetStage):
     """
 
     def expected_outputs(self, dataset: targets.Dataset) -> dict[str, Path]:
-        dataset_prefix = dataset.tmp_prefix() / 'exomiser_inputs'
+        dataset_prefix = dataset.tmp_prefix() / 'exomiser' / 'inputs'
         return {proband: dataset_prefix / f'{proband}.ped' for proband in find_probands(dataset)}
 
     def queue_jobs(self, dataset: targets.Dataset, inputs: stage.StageInput) -> stage.StageOutput:


### PR DESCRIPTION
# Purpose

  - need to enable alternative Exomiser and Exomiser-reference-data versions
  
## Proposed Changes

  - Updates config to be self-sufficient (no reliance on CPG-global config)
  - moves outputs from `-analysis` to just the main bucket
  - Moves inputs from `bucket/exomiser_inputs` to `bucket/exomiser/inputs` to match output structure and stop cluttering up buckets.
  - doubly-namespaces all outputs to be `exomiser/Exomiser_version/Data_version` instead of just `exomiser` or `exomiser_14` (next run will be 14.1.0, and each Exomiser Version can run on various data releases, so that coarse naming strategy is not going to work). 
  - Collects everything under `exomiser` instead of splitting inputs, outputs, and aggregate outputs, less clutter.
  - Introduces a callable method to populate the analysis entry metadata - now we track the exomiser analysis type + software version + data version when evaluating if a run's results already exist