### PR TITLE
Workflow contains data version config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,9 +17,10 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.12.0
+    rev: v0.14.0
     hooks:
       - id: ruff
+      - id: ruff-format
 
   # Static type analysis (as much as it's possible in python using type hints)
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ commit_args = ""
 
 [[tool.bumpversion.files]]
 filename = "pyproject.toml"
-search = "version='{current_version}'"
+search = 'version="{current_version}"'
 replace = "version='{new_version}'"
 
 [[tool.bumpversion.files]]

--- a/src/cpg_exomiser/config_template.toml
+++ b/src/cpg_exomiser/config_template.toml
@@ -2,7 +2,7 @@
 name = 'exomiser'
 status_reporter = 'metamist'
 
-exomiser_version = '14.1.0'
+exomiser_version = '13.3.0'
 exomiser_data_version = '2502'
 
 # in addition to these fields, you will need to supply input_cohorts, and a sequencing_type
@@ -10,8 +10,8 @@ exomiser_data_version = '2502'
 
 # attributes to provision the Exomiser VMs
 # Much lower storage req. - CADD & REMM not in use
-exomiser_memory = '60Gi'
-exomiser_storage = '100Gi'
+exomiser_memory = '100Gi'
+exomiser_storage = '200Gi'
 exomiser_cpu = 4
 
 # number of exomiser jobs to fit onto each VM
@@ -25,7 +25,7 @@ check_expected_outputs = true
 
 [images]
 bcftools = "australia-southeast1-docker.pkg.dev/cpg-common/images/bcftools:1.21-2"
-exomiser = "australia-southeast1-docker.pkg.dev/cpg-common/images/exomiser:14.1.0-1"
+exomiser = "australia-southeast1-docker.pkg.dev/cpg-common/images/exomiser:13.3.0-1"
 
 [references]
 exomiser_2402_pheno = "gs://cpg-common-main/references/exomiser_2402/phenotype"

--- a/src/cpg_exomiser/config_template.toml
+++ b/src/cpg_exomiser/config_template.toml
@@ -2,8 +2,8 @@
 name = 'exomiser'
 status_reporter = 'metamist'
 
-exomiser_version = '13.3.0'
-exomiser_data_version = '2502'
+exomiser_version = '14.1.0'
+exomiser_data_version = '2508'
 
 # in addition to these fields, you will need to supply input_cohorts, and a sequencing_type
 # cpg-flow will use this to query metamist, and set up the pipeline framework
@@ -25,10 +25,12 @@ check_expected_outputs = true
 
 [images]
 bcftools = "australia-southeast1-docker.pkg.dev/cpg-common/images/bcftools:1.21-2"
-exomiser = "australia-southeast1-docker.pkg.dev/cpg-common/images/exomiser:13.3.0-1"
+exomiser = "australia-southeast1-docker.pkg.dev/cpg-common/images/exomiser:14.1.0-3"
 
 [references]
 exomiser_2402_pheno = "gs://cpg-common-main/references/exomiser_2402/phenotype"
 exomiser_2402_core = "gs://cpg-common-main/references/exomiser_2402/core"
 exomiser_2502_pheno = "gs://cpg-common-main/references/exomiser_2502/phenotype"
 exomiser_2502_core = "gs://cpg-common-main/references/exomiser_2502/core"
+exomiser_2508_pheno = "gs://cpg-common-main/references/exomiser_2508/phenotype"
+exomiser_2508_core = "gs://cpg-common-main/references/exomiser_2508/core"

--- a/src/cpg_exomiser/jobs/RunExomiser.py
+++ b/src/cpg_exomiser/jobs/RunExomiser.py
@@ -44,6 +44,17 @@ def run_exomiser(content_dict: dict) -> list['BashJob']:
         job = make_an_exomiser_job(f'Run Exomiser for chunk {chunk_number}')
         all_jobs.append(job)
 
+        # create the application.properties file, responsive to version ARGs
+        # this used to be baked into the Dockerfile, but that approach doesn't provide flexibility to alter data ver.
+        job.command(f"""
+echo "exomiser.data-directory=/exomiser/${{EXOMISER_STEM}}/data" > /exomiser/${{EXOMISER_STEM}}/application.properties
+echo "exomiser.hg38.data-version={EXOMISER_DATA_VERSION}" >> /exomiser/${{EXOMISER_STEM}}/application.properties
+echo "exomiser.phenotype.data-version={EXOMISER_DATA_VERSION}" >> /exomiser/${{EXOMISER_STEM}}/application.properties
+echo "exomiser.hg38.clin-var-data-version={EXOMISER_DATA_VERSION}" >> /exomiser/${{EXOMISER_STEM}}/application.properties
+echo "exomiser.hg38.use-clinvar-white-list=true" >> /exomiser/${{EXOMISER_STEM}}/application.properties
+echo "logging.level.com.zaxxer.hikari=ERROR" >> /exomiser/${{EXOMISER_STEM}}/application.properties
+""")
+
         # unpack references, see linux-install link above
         job.command(rf'unzip {inputs}/\* -d "{exomiser_dir}/data"')
 

--- a/src/cpg_exomiser/jobs/RunExomiser.py
+++ b/src/cpg_exomiser/jobs/RunExomiser.py
@@ -53,7 +53,7 @@ echo "exomiser.phenotype.data-version={EXOMISER_DATA_VERSION}" >> /exomiser/${{E
 echo "exomiser.hg38.clin-var-data-version={EXOMISER_DATA_VERSION}" >> /exomiser/${{EXOMISER_STEM}}/application.properties
 echo "exomiser.hg38.use-clinvar-white-list=true" >> /exomiser/${{EXOMISER_STEM}}/application.properties
 echo "logging.level.com.zaxxer.hikari=ERROR" >> /exomiser/${{EXOMISER_STEM}}/application.properties
-""")
+""")  # noqa: E501
 
         # unpack references, see linux-install link above
         job.command(rf'unzip {inputs}/\* -d "{exomiser_dir}/data"')

--- a/src/cpg_exomiser/run_workflow.py
+++ b/src/cpg_exomiser/run_workflow.py
@@ -8,7 +8,7 @@ from argparse import ArgumentParser
 
 from cpg_flow import workflow
 
-from cpg_exomiser.stages import CombineExomiserGeneTsvs, CombineExomiserVariantTsvs
+from cpg_exomiser.stages import CombineExomiserGeneTsvs, CombineExomiserVariantTsvs, RegisterSingleSampleExomiserResults
 
 
 def cli_main() -> None:
@@ -19,7 +19,7 @@ def cli_main() -> None:
     parser.add_argument('--dry_run', action='store_true', help='Dry run')
     args = parser.parse_args()
 
-    stages = [CombineExomiserGeneTsvs, CombineExomiserVariantTsvs]
+    stages = [CombineExomiserGeneTsvs, CombineExomiserVariantTsvs, RegisterSingleSampleExomiserResults]
 
     workflow.run_workflow(stages=stages, dry_run=args.dry_run)
 

--- a/src/cpg_exomiser/stages.py
+++ b/src/cpg_exomiser/stages.py
@@ -240,8 +240,8 @@ class CombineExomiserGeneTsvs(stage.DatasetStage):
     def expected_outputs(self, dataset: targets.Dataset) -> dict[str, Path]:
         return {
             'tsv': dataset.prefix()
-            / stage.get_workflow().output_version
             / 'exomiser'
+            / stage.get_workflow().output_version
             / EXOMISER_VERSION
             / EXOMISER_DATA_VERSION
             / 'exomiser_results.tsv'
@@ -284,8 +284,8 @@ class CombineExomiserVariantTsvs(stage.DatasetStage):
     def expected_outputs(self, dataset: targets.Dataset) -> dict[str, Path]:
         prefix = (
             dataset.prefix()
-            / stage.get_workflow().output_version
             / 'exomiser'
+            / stage.get_workflow().output_version
             / EXOMISER_VERSION
             / EXOMISER_DATA_VERSION
         )

--- a/src/cpg_exomiser/stages.py
+++ b/src/cpg_exomiser/stages.py
@@ -182,7 +182,7 @@ class RegisterSingleSampleExomiserResults(stage.SequencingGroupStage):
     this is a tricky little fella'
     The previous Stage, RunExomiser, runs per-Dataset, but writes output per-Proband
     The reason is that Exomiser instances are expensive (time and compute) to start up, so we start a few instances,
-    and really crush high numbers of samples through each VM. That's really cost effective, but it means that the
+    and really crush high numbers of samples through each VM. That's really cost-effective, but it means that the
     expected_outputs dict is populated at runtime, so the individual output files can't be entered into analysis_keys
     That means that we can't write the per-proband result entries to metamist, from the previous stage, so we do it here
     """


### PR DESCRIPTION
# Purpose

  - Twinned with https://github.com/populationgenomics/images/pull/261

## Proposed Changes

  - moves the exomiser setup (creation/editing the application config) into the workflow, not the docker build
  - should hopefully enable flexibility (multiple data versions, single exomiser version)
