### PR TITLE
include variant and phenotype score in the JSON output

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -16,7 +16,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 0.1.1
+  VERSION: 0.1.2
 
 jobs:
   docker:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='CPG-Flow implementation of Exomiser Workflow'
 readme = "README.md"
 # currently cpg-flow is restricted to 3.10
 requires-python = ">=3.10,<3.11"
-version="0.1.1"
+version="0.1.2"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -95,7 +95,7 @@ section-order = ["future", "standard-library", "third-party", "first-party", "lo
 "src/cpg_exomiser/stages.py" = ["ARG002"]
 
 [tool.bumpversion]
-current_version = "0.1.1"
+current_version = "0.1.2"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/cpg_exomiser/config_template.toml
+++ b/src/cpg_exomiser/config_template.toml
@@ -1,5 +1,6 @@
 [workflow]
 name = 'exomiser'
+
 status_reporter = 'metamist'
 
 exomiser_version = '14.1.0'

--- a/src/cpg_exomiser/scripts/combine_exomiser_variant_tsvs.py
+++ b/src/cpg_exomiser/scripts/combine_exomiser_variant_tsvs.py
@@ -60,12 +60,18 @@ def process_tsv(tsv_path: str) -> tuple[PROBAND_DICT, VAR_DICT]:
 
             rank = int(row['#RANK'])
             moi = row['MOI']
+            phenotype_score = row['EXOMISER_GENE_PHENO_SCORE']
+            gene_variant_score = row['EXOMISER_GENE_VARIANT_SCORE']
+            variant_score = row['EXOMISER_VARIANT_SCORE']
 
             # adds easily parsed details to the family dictionary, easily extensible
             proband_dictionary[proband][variant_key].append(
                 {
                     'rank': rank,
                     'moi': moi,
+                    'gene_variant_score': gene_variant_score,
+                    'variant_score': variant_score,
+                    'phenotype_score': phenotype_score,
                 },
             )
 


### PR DESCRIPTION
# Purpose

  - The whole-cohort JSON aggregation of the Variant TSVs doesn't currently collect the phenotype/variant scores required to run cross-exomiser-version deltas using the suggested parameters from https://pmc.ncbi.nlm.nih.gov/articles/PMC11655964/

## Proposed Changes

  - adds Pheno, Gene_variant, and Variant scores into the JSON summary file
